### PR TITLE
enabled custom header support

### DIFF
--- a/wp-content/themes/dosomething-blog/functions.php
+++ b/wp-content/themes/dosomething-blog/functions.php
@@ -22,6 +22,7 @@ function dequeue_theme_scripts() {
 
 add_action('wp_enqueue_scripts','dequeue_theme_scripts', 100);
 
+
 class Theme
 {
     function init($options)
@@ -132,6 +133,7 @@ class Theme
         add_theme_support('menus');
         add_theme_support('automatic-feed-links');
         add_theme_support('editor-style');
+        add_theme_support('custom-header');
         register_nav_menus(array(
             'primary-menu' => 'Primary Navigation',
             'second-menu' => 'Second Navigation',

--- a/wp-content/themes/dosomething-blog/header.php
+++ b/wp-content/themes/dosomething-blog/header.php
@@ -409,6 +409,9 @@ if($post_id) {
     <h1 class="__title">Big, Loud, &amp; Easy</h1>
     <h2 class="__subtitle">A DoSomething.org Blog</h2>
   </div>
+  <?php if ( get_header_image() ) : ?>
+    <img src="<?php header_image(); ?>" >
+  <?php endif; ?>
 </header>
 
 <?php 

--- a/wp-content/themes/dosomething-blog/scss/regions/_chrome.scss
+++ b/wp-content/themes/dosomething-blog/scss/regions/_chrome.scss
@@ -101,15 +101,12 @@
 }
 
 .-hero[role="banner"] {
-  background-image: url("../dist/images/blog_hero_768x768.jpg");
+  //background-image: url("../dist/images/blog_hero_768x768.jpg");
   height: 310px;
-
-  @include media($tablet) {
-    background-image: url("../dist/images/blog_hero_1440x465.jpg");
-  }
 
   > .wrapper {
     text-align: center;
+    z-index: 2;
   }
 
   .__title {
@@ -120,6 +117,13 @@
     letter-spacing: 0.1em;
     text-transform: uppercase;
     width: auto;
+  }
+
+  img {
+    display: block;
+    left: 0;
+    position: absolute;
+    top: 0;
   }
 }
 


### PR DESCRIPTION
Adds support to upload a custom header image from WP admin under: 

**Appearance -> Header**

![image](https://cloud.githubusercontent.com/assets/1566749/5364898/6ed1a3ce-7fb5-11e4-87e3-11a886c0365d.png)

Resolves #72 
