### PR TITLE
Show excerpt if set, otherwise use content.

### DIFF
--- a/web/app/themes/dosomething/partials/content.php
+++ b/web/app/themes/dosomething/partials/content.php
@@ -29,11 +29,15 @@
             </header>
 
             <?php
-            the_content( sprintf(
-            /* translators: %s: Name of current post. */
-              wp_kses( __( 'Continue reading&hellip;' ), array( 'p' => array( 'class' => array('footnote') ) ) ),
-              the_title( '<span class="screen-reader-text">"', '"</span>', false )
-            ) );
+              if(empty($post->post_excerpt)) {
+                the_content( sprintf(
+                  wp_kses( __( 'Continue reading&hellip;' ), array( 'p' => array( 'class' => array('footnote') ) ) ),
+                  the_title( '<span class="screen-reader-text">"', '"</span>', false )
+                ) );
+              } else {
+                echo '<p>' . $post->post_excerpt . '</p>';
+                echo '<p class="footnote"><a href="' . esc_url(get_permalink()) . '">Continue reading&hellip;</a></p>';
+              }
             ?>
 
           </div>


### PR DESCRIPTION
#### Changes

Use the excerpt if set, but otherwise show post content until a "Read More" tag.

Messy, but it works.
#### Example

![screen shot 2015-11-05 at 4 21 00 pm](https://cloud.githubusercontent.com/assets/583202/10982106/714c603e-83d9-11e5-9caf-f12650e81f91.png)
